### PR TITLE
Added cmdlet for determining Secret Server's version.

### DIFF
--- a/SecretServer/Get-SSVersion.ps1
+++ b/SecretServer/Get-SSVersion.ps1
@@ -6,13 +6,13 @@
 
     .DESCRIPTION
         Gets the version of Secret Server.
-		
-	.EXAMPLE
-		#Compares the version of Secret Server against a known version.
-		
-		$Version = Get-SSVersion
-		if ($Version -lt [Version]"8.0.0") 
-	
+
+    .EXAMPLE
+        #Compares the version of Secret Server against a known version.
+        
+        $Version = Get-SSVersion
+        if ($Version -lt [Version]"8.0.0") 
+    
     .FUNCTIONALITY
         Secret Server
 
@@ -40,11 +40,11 @@
     }
     Process
     {
-		$VersionResult = $WebServiceProxy.VersionGet()
-		if ($VersionResult.Errors.Length -gt 0)
-		{
-			Throw "Secret Server reported an error while calling VersionGet."
-		}
+        $VersionResult = $WebServiceProxy.VersionGet()
+        if ($VersionResult.Errors.Length -gt 0)
+        {
+            Throw "Secret Server reported an error while calling VersionGet."
+        }
         Return [Version]$VersionResult.Version
     }
 }

--- a/SecretServer/Get-SSVersion.ps1
+++ b/SecretServer/Get-SSVersion.ps1
@@ -1,0 +1,50 @@
+﻿Function Get-SSVersion
+{
+    <#
+    .SYNOPSIS
+        Gets the version of Secret Server.
+
+    .DESCRIPTION
+        Gets the version of Secret Server.
+		
+	.EXAMPLE
+		#Compares the version of Secret Server against a known version.
+		
+		$Version = Get-SSVersion
+		if ($Version -lt [Version]"8.0.0") 
+	
+    .FUNCTIONALITY
+        Secret Server
+
+    #>
+    [cmdletbinding()]
+    param(
+        [string]$Uri = $SecretServerConfig.Uri,
+        [System.Web.Services.Protocols.SoapHttpClientProtocol]$WebServiceProxy = $SecretServerConfig.Proxy
+    )
+    Begin
+    {
+        Write-Verbose "Working with PSBoundParameters $($PSBoundParameters | Out-String)"
+        if(-not $WebServiceProxy.whoami)
+        {
+            Write-Warning "Your SecretServerConfig proxy does not appear connected.  Creating new connection to $uri"
+            try
+            {
+                $WebServiceProxy = New-WebServiceProxy -uri $Uri -UseDefaultCredential -ErrorAction stop
+            }
+            catch
+            {
+                Throw "Error creating proxy for $Uri`: $_"
+            }
+        }
+    }
+    Process
+    {
+		$VersionResult = $WebServiceProxy.VersionGet()
+		if ($VersionResult.Errors.Length -gt 0)
+		{
+			Throw "Secret Server reported an error while calling VersionGet."
+		}
+        Return [Version]$VersionResult.Version
+    }
+}


### PR DESCRIPTION
This allows you to check the version of Secret Server. It encompasses the version as a System.Version object which lets you do easy comparisons as noted in the documentation for the new cmdlet.

Eventually this can be used internally by the module itself (probably by caching the result into a variable) to warn when certain cmdlets aren't available in a particular version of Secret Server.

I did my best to follow existing conventions of cmdlets, let me know if there is something I did wrong here.
